### PR TITLE
 CASSANDRA-15714 Support for replacing logback with alternate logger config (like log4j2)

### DIFF
--- a/src/main/java/org/apache/cassandra/distributed/api/ICluster.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/ICluster.java
@@ -92,13 +92,11 @@ public interface ICluster<I extends IInstance> extends AutoCloseable
             File root = Files.createTempDirectory("in-jvm-dtest").toFile();
             root.deleteOnExit();
             String logConfigPropertyName = System.getProperty(PROPERTY_PREFIX + ".logConfigProperty", "logback.configurationFile");
-            String testConfPath = System.getProperty(PROPERTY_PREFIX + ".logConfigPath", "test/conf/logback-dtest.xml");
-            Path logConfPath = Paths.get(root.getPath(), "/logback-dtest.xml");
-
+            Path testConfPath = Paths.get(System.getProperty(PROPERTY_PREFIX + ".logConfigPath", "test/conf/logback-dtest.xml"));
+            Path logConfPath = Paths.get(root.getPath(), testConfPath.getFileName().toString());
             if (!logConfPath.toFile().exists())
             {
-                Files.copy(new File(testConfPath).toPath(),
-                           logConfPath);
+                Files.copy(testConfPath, logConfPath);
             }
 
             System.setProperty(logConfigPropertyName, "file://" + logConfPath);

--- a/src/main/java/org/apache/cassandra/distributed/api/ICluster.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/ICluster.java
@@ -28,6 +28,8 @@ import java.util.stream.Stream;
 
 public interface ICluster<I extends IInstance> extends AutoCloseable
 {
+    public static final String PROPERTY_PREFIX = "cassandra.test";
+
     void startup();
 
     I bootstrap(IInstanceConfig config);
@@ -89,7 +91,8 @@ public interface ICluster<I extends IInstance> extends AutoCloseable
         {
             File root = Files.createTempDirectory("in-jvm-dtest").toFile();
             root.deleteOnExit();
-            String testConfPath = "test/conf/logback-dtest.xml";
+            String logConfigPropertyName = System.getProperty(PROPERTY_PREFIX + ".logConfigProperty", "logback.configurationFile");
+            String testConfPath = System.getProperty(PROPERTY_PREFIX + ".logConfigPath", "test/conf/logback-dtest.xml");
             Path logConfPath = Paths.get(root.getPath(), "/logback-dtest.xml");
 
             if (!logConfPath.toFile().exists())
@@ -98,7 +101,7 @@ public interface ICluster<I extends IInstance> extends AutoCloseable
                            logConfPath);
             }
 
-            System.setProperty("logback.configurationFile", "file://" + logConfPath);
+            System.setProperty(logConfigPropertyName, "file://" + logConfPath);
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Not all forks use logback, and there is an (prematurely) closed ticket
indicating that it would be valuable CASSANDRA-13212.

Also had to add 'org.w3c.dom' to the InstanceClassLoader so that
log4j2 could load it's configuration.

Patch by Jon Meredith; reviewed by ? for CASSANDRA-15714.