### PR TITLE
CASSANDRA-15920 make SimpleQueryResult a container for client warnings, and expose those warnings via QueryResult

### DIFF
--- a/src/main/java/org/apache/cassandra/distributed/api/QueryResult.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/QueryResult.java
@@ -58,6 +58,8 @@ import java.util.function.Predicate;
 public interface QueryResult extends Iterator<Row>
 {
     List<String> names();
+    
+    List<String> warnings();
 
     default QueryResult filter(Predicate<Row> fn)
     {

--- a/src/main/java/org/apache/cassandra/distributed/api/QueryResults.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/QueryResults.java
@@ -80,7 +80,8 @@ public final class QueryResults
 
         private int numColumns = UNSET;
         private String[] names;
-        private List<Object[]> results = new ArrayList<>();
+        private final List<Object[]> results = new ArrayList<>();
+        private final List<String> warnings = new ArrayList<>();
 
         public Builder columns(String... columns)
         {
@@ -110,6 +111,12 @@ public final class QueryResults
             return this;
         }
 
+        public Builder warning(String message)
+        {
+            warnings.add(message);
+            return this;
+        }
+
         public SimpleQueryResult build()
         {
             if (names == null)
@@ -120,7 +127,8 @@ public final class QueryResults
                 for (int i = 0; i < numColumns; i++)
                     names[i] = "unknown";
             }
-            return new SimpleQueryResult(names, results.stream().toArray(Object[][]::new));
+            
+            return new SimpleQueryResult(names, results.toArray(new Object[0][]), warnings);
         }
     }
 
@@ -144,6 +152,12 @@ public final class QueryResults
         public List<String> names()
         {
             return names;
+        }
+
+        @Override
+        public List<String> warnings()
+        {
+            throw new UnsupportedOperationException("Warnings are not yet supported for " + getClass().getSimpleName());
         }
 
         @Override
@@ -175,6 +189,12 @@ public final class QueryResults
         public List<String> names()
         {
             return delegate.names();
+        }
+        
+        @Override 
+        public List<String> warnings()
+        {
+            return delegate.warnings();
         }
 
         @Override

--- a/src/main/java/org/apache/cassandra/distributed/api/SimpleQueryResult.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/SimpleQueryResult.java
@@ -63,14 +63,21 @@ public class SimpleQueryResult implements QueryResult
 {
     private final String[] names;
     private final Object[][] results;
+    private final List<String> warnings;
     private final Predicate<Row> filter;
     private final Row row;
     private int offset = -1;
 
     public SimpleQueryResult(String[] names, Object[][] results)
     {
+        this(names, results, Collections.emptyList());
+    }
+
+    public SimpleQueryResult(String[] names, Object[][] results, List<String> warnings)
+    {
         this.names = Objects.requireNonNull(names, "names");
         this.results = results;
+        this.warnings = Objects.requireNonNull(warnings, "warnings");
         this.row = new Row(names);
         this.filter = ignore -> true;
     }
@@ -79,6 +86,7 @@ public class SimpleQueryResult implements QueryResult
     {
         this.names = names;
         this.results = results;
+        this.warnings = Collections.emptyList();
         this.filter = filter;
         this.offset = offset;
         this.row = new Row(names);
@@ -87,6 +95,12 @@ public class SimpleQueryResult implements QueryResult
     public List<String> names()
     {
         return Collections.unmodifiableList(Arrays.asList(names));
+    }
+
+    @Override
+    public List<String> warnings()
+    {
+        return Collections.unmodifiableList(warnings);
     }
 
     public SimpleQueryResult filter(Predicate<Row> fn)


### PR DESCRIPTION
This change should provide sufficient hooks for `ICoordinator` implementations to provide client warnings in their results while avoiding any backwards-incompatible changes to either `QueryResult` or its implementations.