### PR TITLE
Include captured console output string in NodeToolResult

### DIFF
--- a/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
@@ -36,22 +36,22 @@ public class NodeToolResult
     private final int rc;
     private final List<Notification> notifications;
     private final Throwable error;
-    private final String capturedConsoleOut;
-    private final String capturedConsoleErr;
+    private final String stdout;
+    private final String stderr;
 
     public NodeToolResult(String[] commandAndArgs, int rc, List<Notification> notifications, Throwable error)
     {
         this(commandAndArgs, rc, notifications, error, null, null);
     }
 
-    public NodeToolResult(String[] commandAndArgs, int rc, List<Notification> notifications, Throwable error, String capturedOut, String capturedErr)
+    public NodeToolResult(String[] commandAndArgs, int rc, List<Notification> notifications, Throwable error, String stdout, String stderr)
     {
         this.commandAndArgs = commandAndArgs;
         this.rc = rc;
         this.notifications = notifications;
         this.error = error;
-        this.capturedConsoleErr = capturedErr;
-        this.capturedConsoleOut = capturedOut;
+        this.stdout = stdout;
+        this.stderr = stderr;
     }
 
     public String[] getCommandAndArgs()
@@ -74,14 +74,14 @@ public class NodeToolResult
         return error;
     }
 
-    public String getStdOut()
+    public String getStdout()
     {
-        return capturedConsoleOut;
+        return stdout;
     }
 
-    public String getStdErr()
+    public String getStderr()
     {
-        return capturedConsoleErr;
+        return stderr;
     }
 
     public Asserts asserts()
@@ -163,10 +163,10 @@ public class NodeToolResult
             return capturedConsoleOutputContains(substring, false);
         }
 
-        private Asserts capturedConsoleOutputContains(String substring, boolean isOut)
+        private Asserts capturedConsoleOutputContains(String substring, boolean isStdout)
         {
-            String name = isOut ? "capturedConsoleOut" : "capturedConsoleErr";
-            String output = isOut ? capturedConsoleOut : capturedConsoleErr;
+            String name = isStdout ? "stdout" : "stderr";
+            String output = isStdout ? stdout : stderr;
             AssertUtils.assertNotNull(name + " not defined", output);
             if (output.contains(substring))
             {

--- a/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
@@ -37,12 +37,22 @@ public class NodeToolResult
     private final List<Notification> notifications;
     private final Throwable error;
 
+    public final String capturedConsoleOut;
+    public final String capturedConsoleErr;
+
     public NodeToolResult(String[] commandAndArgs, int rc, List<Notification> notifications, Throwable error)
+    {
+        this(commandAndArgs, rc, notifications, error, null, null);
+    }
+
+    public NodeToolResult(String[] commandAndArgs, int rc, List<Notification> notifications, Throwable error, String capturedOut, String capturedErr)
     {
         this.commandAndArgs = commandAndArgs;
         this.rc = rc;
         this.notifications = notifications;
         this.error = error;
+        this.capturedConsoleErr = capturedErr;
+        this.capturedConsoleOut = capturedOut;
     }
 
     public String[] getCommandAndArgs()
@@ -131,6 +141,30 @@ public class NodeToolResult
                 }
             }
             fail("Unable to locate message '" + msg + "' in notifications: " + NodeToolResult.toString(notifications));
+            return this; // unreachable
+        }
+
+        public Asserts capturedConsoleOutContains(String substring)
+        {
+            return capturedConsoleOutputContains(substring, true);
+        }
+
+        public Asserts capturedConsoleErrContains(String substring)
+        {
+            return capturedConsoleOutputContains(substring, false);
+        }
+
+        private Asserts capturedConsoleOutputContains(String substring, boolean isOut)
+        {
+            String name = isOut ? "capturedConsoleOut" : "capturedConsoleErr";
+            String output = isOut ? capturedConsoleOut : capturedConsoleErr;
+            AssertUtils.assertNotNull(name + " not defined", output);
+            AssertUtils.assertFalse("Found no " + name, output.isEmpty());
+            if (output.contains(substring))
+            {
+                return this;
+            }
+            fail("Unable to locate substring '" + substring + "' in " + name + ": " + output);
             return this; // unreachable
         }
 

--- a/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
@@ -155,24 +155,46 @@ public class NodeToolResult
 
         public Asserts stdoutContains(String substring)
         {
-            return capturedConsoleOutputContains(substring, true);
+            return assertConsoleOutput(substring, true, true);
         }
 
         public Asserts stderrContains(String substring)
         {
-            return capturedConsoleOutputContains(substring, false);
+            return assertConsoleOutput(substring, false, true);
         }
 
-        private Asserts capturedConsoleOutputContains(String substring, boolean isStdout)
+        public Asserts stdoutNotContains(String substring)
+        {
+            return assertConsoleOutput(substring, true, false);
+        }
+
+        public Asserts stderrNotContains(String substring)
+        {
+            return assertConsoleOutput(substring, false, false);
+        }
+
+        private Asserts assertConsoleOutput(String substring, boolean isStdout, boolean assertContains)
         {
             String name = isStdout ? "stdout" : "stderr";
             String output = isStdout ? stdout : stderr;
             AssertUtils.assertNotNull(name + " not defined", output);
-            if (output.contains(substring))
+            if (assertContains)
             {
-                return this;
+                if (output.contains(substring))
+                {
+                    return this;
+                }
+                fail("Unable to locate substring '" + substring + "' in " + name + ": " + output);
             }
-            fail("Unable to locate substring '" + substring + "' in " + name + ": " + output);
+            else
+            {
+                if (!output.contains(substring))
+                {
+                    return this;
+                }
+                fail("Found unexpected substring '" + substring + "' in " + name + ": " + output);
+            }
+
             return this; // unreachable
         }
 

--- a/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/NodeToolResult.java
@@ -36,9 +36,8 @@ public class NodeToolResult
     private final int rc;
     private final List<Notification> notifications;
     private final Throwable error;
-
-    public final String capturedConsoleOut;
-    public final String capturedConsoleErr;
+    private final String capturedConsoleOut;
+    private final String capturedConsoleErr;
 
     public NodeToolResult(String[] commandAndArgs, int rc, List<Notification> notifications, Throwable error)
     {
@@ -73,6 +72,16 @@ public class NodeToolResult
     public Throwable getError()
     {
         return error;
+    }
+
+    public String getStdOut()
+    {
+        return capturedConsoleOut;
+    }
+
+    public String getStdErr()
+    {
+        return capturedConsoleErr;
     }
 
     public Asserts asserts()
@@ -144,12 +153,12 @@ public class NodeToolResult
             return this; // unreachable
         }
 
-        public Asserts capturedConsoleOutContains(String substring)
+        public Asserts stdoutContains(String substring)
         {
             return capturedConsoleOutputContains(substring, true);
         }
 
-        public Asserts capturedConsoleErrContains(String substring)
+        public Asserts stderrContains(String substring)
         {
             return capturedConsoleOutputContains(substring, false);
         }
@@ -159,7 +168,6 @@ public class NodeToolResult
             String name = isOut ? "capturedConsoleOut" : "capturedConsoleErr";
             String output = isOut ? capturedConsoleOut : capturedConsoleErr;
             AssertUtils.assertNotNull(name + " not defined", output);
-            AssertUtils.assertFalse("Found no " + name, output.isEmpty());
             if (output.contains(substring))
             {
                 return this;

--- a/src/test/java/org/apache/cassandra/distributed/api/NodeToolOutputTest.java
+++ b/src/test/java/org/apache/cassandra/distributed/api/NodeToolOutputTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.api;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+public class NodeToolOutputTest
+{
+    @Test
+    public void testAssertOutputNoThrow()
+    {
+        NodeToolResult result = create("stdout", "stderr");
+        result.asserts().stdoutContains("out");
+        result.asserts().stderrContains("err");
+        result.asserts().stdoutNotContains("hello");
+        result.asserts().stderrNotContains("world");
+    }
+
+    @Test
+    public void testAssertContainsWithNoOutput()
+    {
+        NodeToolResult result = create(null, null);
+        Throwable exception = catchThrowableOfType(() -> {
+            result.asserts().stdoutContains("foo");
+        }, AssertionError.class);
+        assertThat(exception.getMessage()).isEqualTo("stdout not defined");
+
+        exception = catchThrowableOfType(() -> {
+            result.asserts().stdoutNotContains("foo");
+        }, AssertionError.class);
+        assertThat(exception.getMessage()).isEqualTo("stdout not defined");
+    }
+
+    @Test
+    public void testAssertContainsFails()
+    {
+        NodeToolResult result = create("stdout", "stderr");
+        Throwable exception = catchThrowableOfType(() -> {
+           result.asserts().stdoutContains("foo");
+        }, AssertionError.class);
+        assertThat(exception.getMessage()).contains("Unable to locate substring");
+
+        exception = catchThrowableOfType(() -> {
+            result.asserts().stdoutNotContains("out");
+        }, AssertionError.class);
+        assertThat(exception.getMessage()).contains("Found unexpected substring");
+    }
+
+    private NodeToolResult create(String stdout, String stderr)
+    {
+        return new NodeToolResult(null, 0, Collections.emptyList(), null, stdout, stderr);
+    }
+}


### PR DESCRIPTION
- If captured console output is null, the test code does not implement the capture function
- If captured console output is empty, there is no output captured.