### PR TITLE
Add IInstance#getReleaseVersionString

### DIFF
--- a/src/main/java/org/apache/cassandra/distributed/api/IInstance.java
+++ b/src/main/java/org/apache/cassandra/distributed/api/IInstance.java
@@ -86,6 +86,8 @@ public interface IInstance extends IIsolatedExecutor
 
     void setMessagingVersion(InetSocketAddress addressAndPort, int version);
 
+    String getReleaseVersionString();
+
     void flush(String keyspace);
 
     void forceCompact(String keyspace, String table);


### PR DESCRIPTION
See CASSANDRA-16148. We need this version string to add to gossip state when `Feature.GOSSIP` is not being used. 