### PR TITLE
CASSANDRA-19783 InstanceClassLoader leak detection

### DIFF
--- a/src/main/java/org/apache/cassandra/distributed/shared/InstanceClassLoader.java
+++ b/src/main/java/org/apache/cassandra/distributed/shared/InstanceClassLoader.java
@@ -31,8 +31,11 @@ import java.net.URLConnection;
 import java.security.CodeSigner;
 import java.security.CodeSource;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.function.Predicate;
 import java.util.jar.Manifest;
 
@@ -56,6 +59,12 @@ public class InstanceClassLoader extends URLClassLoader
               || name.startsWith("org.jboss.byteman.")
               || name.startsWith("oshi.jna.");
 
+    // Use a WeakHashMap to get the approximate count of live classloaders.
+    // Once the classloader is otherwise unused, GC will (eventually) remove it from this set as well.
+    // NOTE: Because potentially incompletely-initialized loaders are published to this set, do not expose the set
+    // itself other than through the getApproximateLiveLoaderCount method.
+    private static final Set<InstanceClassLoader> liveLoaders = Collections.synchronizedSet(
+                                                                Collections.newSetFromMap(new WeakHashMap<>()));
     private volatile boolean isClosed = false;
     private final URL[] urls;
     private final int generation; // used to help debug class loader leaks, by helping determine which classloaders should have been collected
@@ -88,11 +97,19 @@ public class InstanceClassLoader extends URLClassLoader
         this.id = id;
         this.loadShared = loadShared == null ? DEFAULT_SHARED_PACKAGES : loadShared;
         this.transform = transform;
+        liveLoaders.add(this);
     }
 
     public static Predicate<String> getDefaultLoadSharedFilter()
     {
         return DEFAULT_SHARED_PACKAGES;
+    }
+
+    public static int getApproximateLiveLoaderCount(boolean forceGC) {
+        if (forceGC) {
+            System.gc();
+        }
+        return liveLoaders.size();
     }
 
     public int getClusterGeneration()

--- a/src/main/java/org/apache/cassandra/distributed/shared/InstanceClassLoader.java
+++ b/src/main/java/org/apache/cassandra/distributed/shared/InstanceClassLoader.java
@@ -105,8 +105,10 @@ public class InstanceClassLoader extends URLClassLoader
         return DEFAULT_SHARED_PACKAGES;
     }
 
-    public static int getApproximateLiveLoaderCount(boolean forceGC) {
-        if (forceGC) {
+    public static int getApproximateLiveLoaderCount(boolean forceGC)
+    {
+        if (forceGC)
+        {
             System.gc();
         }
         return liveLoaders.size();

--- a/src/test/java/org/apache/cassandra/distributed/shared/InstanceClassLoaderTest.java
+++ b/src/test/java/org/apache/cassandra/distributed/shared/InstanceClassLoaderTest.java
@@ -32,25 +32,11 @@ public class InstanceClassLoaderTest
 {
 
     private static final int NUM_LOADERS = 10;
-    private List<InstanceClassLoader> loaders = new ArrayList<>();
-
-    @BeforeEach
-    public void ensureNoClassLoadersOnStart() {
-        assertThat(waitForZeroClassLoaders(50)).isTrue();
-    }
-
-    public boolean waitForZeroClassLoaders(int gcAttempts)
-    {
-        int i = 0;
-        while (InstanceClassLoader.getApproximateLiveLoaderCount(true) > 0 && i++ < gcAttempts) {
-            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-        }
-        return InstanceClassLoader.getApproximateLiveLoaderCount(false) == 0;
-
-    }
+    private final List<InstanceClassLoader> loaders = new ArrayList<>();
 
     @Test
-    public void testRefCountZeroWhenNoneCreated() {
+    public void testRefCountZeroWhenNoneCreated()
+    {
         assertThat(InstanceClassLoader.getApproximateLiveLoaderCount(true)).isEqualTo(0);
     }
 
@@ -60,18 +46,36 @@ public class InstanceClassLoaderTest
         createClassLoadersAndAssertCount();
     }
 
-    private void createClassLoadersAndAssertCount()
-    {
-        for (int i = 0; i < NUM_LOADERS; i++) {
-            loaders.add(new InstanceClassLoader(0, 0, new URL[0], this.getClass().getClassLoader()));
-        }
-        assertThat(InstanceClassLoader.getApproximateLiveLoaderCount(true)).isEqualTo(NUM_LOADERS);
-    }
-
     @Test
-    public void testRefCountAfterInstancesCanBeGced() {
+    public void testRefCountAfterInstancesCanBeGced()
+    {
         createClassLoadersAndAssertCount();
         loaders.clear();
         assertThat(waitForZeroClassLoaders(10)).isTrue();
+    }
+
+    @BeforeEach
+    public void ensureNoClassLoadersOnStart()
+    {
+        assertThat(waitForZeroClassLoaders(50)).isTrue();
+    }
+
+    public boolean waitForZeroClassLoaders(int gcAttempts)
+    {
+        int i = 0;
+        while (InstanceClassLoader.getApproximateLiveLoaderCount(true) > 0 && i++ < gcAttempts)
+        {
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+        }
+        return InstanceClassLoader.getApproximateLiveLoaderCount(false) == 0;
+    }
+
+    private void createClassLoadersAndAssertCount()
+    {
+        for (int i = 0; i < NUM_LOADERS; i++)
+        {
+            loaders.add(new InstanceClassLoader(0, 0, new URL[0], this.getClass().getClassLoader()));
+        }
+        assertThat(InstanceClassLoader.getApproximateLiveLoaderCount(true)).isEqualTo(NUM_LOADERS);
     }
 }

--- a/src/test/java/org/apache/cassandra/distributed/shared/InstanceClassLoaderTest.java
+++ b/src/test/java/org/apache/cassandra/distributed/shared/InstanceClassLoaderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.shared;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstanceClassLoaderTest
+{
+
+    private static final int NUM_LOADERS = 10;
+    private List<InstanceClassLoader> loaders = new ArrayList<>();
+
+    @BeforeEach
+    public void ensureNoClassLoadersOnStart() {
+        assertThat(waitForZeroClassLoaders(50)).isTrue();
+    }
+
+    public boolean waitForZeroClassLoaders(int gcAttempts)
+    {
+        int i = 0;
+        while (InstanceClassLoader.getApproximateLiveLoaderCount(true) > 0 && i++ < gcAttempts) {
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+        }
+        return InstanceClassLoader.getApproximateLiveLoaderCount(false) == 0;
+
+    }
+
+    @Test
+    public void testRefCountZeroWhenNoneCreated() {
+        assertThat(InstanceClassLoader.getApproximateLiveLoaderCount(true)).isEqualTo(0);
+    }
+
+    @Test
+    public void testRefCountWhenInstancesCreatedAndStillOnHeap()
+    {
+        createClassLoadersAndAssertCount();
+    }
+
+    private void createClassLoadersAndAssertCount()
+    {
+        for (int i = 0; i < NUM_LOADERS; i++) {
+            loaders.add(new InstanceClassLoader(0, 0, new URL[0], this.getClass().getClassLoader()));
+        }
+        assertThat(InstanceClassLoader.getApproximateLiveLoaderCount(true)).isEqualTo(NUM_LOADERS);
+    }
+
+    @Test
+    public void testRefCountAfterInstancesCanBeGced() {
+        createClassLoadersAndAssertCount();
+        loaders.clear();
+        assertThat(waitForZeroClassLoaders(10)).isTrue();
+    }
+}


### PR DESCRIPTION
This commit adds a WeakHashMap-backed set of InstanceClassLoaders which can be used to count the live instances of classloaders. This, in turn, is used in ResourceLeakTest in Cassandra's main source to detect leaking InstanceClassLoaders, and will allow us to find them in CI before a commit gets through that adds a new leak.